### PR TITLE
Improve Windows compatibility

### DIFF
--- a/cuda_ext.py
+++ b/cuda_ext.py
@@ -11,6 +11,35 @@ import sys
 library_dir = os.path.dirname(os.path.abspath(__file__))
 extension_name = "exllama_ext"
 
+# another kludge to get things compiling in Windows
+windows = os.name == "nt"
+if windows:
+    def find_msvc():
+        for msvc_dir in ["C:\\Program Files" + a + "\\Microsoft Visual Studio\\" + b + "\\" + c + "\\VC\Tools\\MSVC\\"
+            for b in ["2022", "2019", "2017"]
+            for a in ["", " (x86)"]
+            for c in ["BuildTools", "Community", "Professional", "Enterprise", "Preview"]
+        ]:
+            if not os.path.exists(msvc_dir):
+                continue
+            versions = sorted(os.listdir(msvc_dir), reverse=True)
+            for version in versions:
+                compiler_dir = msvc_dir + version + "\\bin\\Hostx64\\x64"
+                if os.path.exists(compiler_dir) and os.path.exists(compiler_dir + "\\cl.exe"):
+                    return compiler_dir
+        return None
+    
+    import subprocess
+    try:
+        subprocess.check_output(["where", "cl"])
+    except subprocess.CalledProcessError as e:
+        cl_path = find_msvc()
+        if cl_path:
+            print("Injected compiler path:", cl_path)
+            os.environ["path"] += ";" + cl_path
+        else:
+            print("Unable to find cl.exe; compilation will probably fail.")
+
 exllama_ext = load(
     name = extension_name,
     sources = [
@@ -31,6 +60,7 @@ exllama_ext = load(
     ],
     # verbose = True,
     # extra_cflags = ["-ftime-report", "-DTORCH_USE_CUDA_DSA"]
+    extra_ldflags=["cublas.lib"] if windows else [],
 )
 
 # from exllama_ext import set_tuning_params

--- a/cuda_ext.py
+++ b/cuda_ext.py
@@ -15,9 +15,9 @@ extension_name = "exllama_ext"
 windows = os.name == "nt"
 if windows:
     def find_msvc():
-        for msvc_dir in ["C:\\Program Files" + a + "\\Microsoft Visual Studio\\" + b + "\\" + c + "\\VC\Tools\\MSVC\\"
+        for msvc_dir in [a + "\\Microsoft Visual Studio\\" + b + "\\" + c + "\\VC\Tools\\MSVC\\"
             for b in ["2022", "2019", "2017"]
-            for a in ["", " (x86)"]
+            for a in [os.environ["ProgramW6432"], os.environ["ProgramFiles(x86)"]]
             for c in ["BuildTools", "Community", "Professional", "Enterprise", "Preview"]
         ]:
             if not os.path.exists(msvc_dir):


### PR DESCRIPTION
- Searches for [MSVC](https://visualstudio.microsoft.com/downloads/)'s `cl.exe` in various likely paths, and injects the compiler path into the `Path` env variable if found, which should solve most errors like e.g. `subprocess.CalledProcessError: Command '['where', 'cl']' returned non-zero exit status 1.` without requiring users to fiddle too much.
- Adds the necessary `extra_ldflags=["cublas.lib"],` kwarg where `torch.utils.cpp_extension.load()` is called in `cuda_ext.py`, which is required in a Windows environment to avoid linker errors such as
```
half_matmul.cuda.o : error LNK2019: unresolved external symbol cublasHgemm referenced in function "enum cudaError __cdecl half_matmul_cublas_cuda(struct __half const *,struct __half const *,struct __half *,int,int,int,struct cublasContext *)" (?half_matmul_cublas_cuda@@YA?AW4cudaError@@PEBU__half@@0PEAU2@HHHPEAUcublasContext@@@Z)
exllama_ext.pyd : fatal error LNK1120: 1 unresolved externals
ninja: build stopped: subcommand failed.
```

Addresses #33.

With this PR, exllama should (hopefully) work on Windows provided necessary compilers/dependencies are installed:
- [MSVC 2022](https://visualstudio.microsoft.com/downloads/); or [`Build Tools for Visual Studio 2022`](https://aka.ms/vs/17/release/vs_BuildTools.exe) w/ `Desktop development with C++ Build Tools` option
- [PyTorch](https://pytorch.org/get-started/locally/)
- [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit-archive) (make sure CUDA versions match, e.g. PyTorch w/ Compute Platform 11.8 + CUDA Toolkit 11.8.0)