### PR TITLE
Fix some cublas hipification

### DIFF
--- a/exllama_ext/hip_compat.cuh
+++ b/exllama_ext/hip_compat.cuh
@@ -40,6 +40,8 @@ __host__ __forceinline__ hipblasStatus_t __compat_hipblasHgemm(hipblasHandle_t  
 
 #define rocblas_handle hipblasHandle_t
 #define rocblas_operation_none HIPBLAS_OP_N
+#define rocblas_get_stream hipblasGetStream
+#define rocblas_set_stream hipblasSetStream
 #define rocblas_hgemm __compat_hipblasHgemm
 
 #endif


### PR DESCRIPTION
3160ae25 added use of cublasGetStream and cublasSetStream. They were getting hipified to rocBLAS instead of hipBLAS.