### PR TITLE
Minor import time output suppression for windows

### DIFF
--- a/cuda_ext.py
+++ b/cuda_ext.py
@@ -30,14 +30,15 @@ if windows:
     
     import subprocess
     try:
-        subprocess.check_output(["where", "cl"])
+        subprocess.check_output(["where", "/Q", "cl"])
     except subprocess.CalledProcessError as e:
         cl_path = find_msvc()
         if cl_path:
-            print("Injected compiler path:", cl_path)
+            if verbose:
+                print("Injected compiler path:", cl_path)
             os.environ["path"] += ";" + cl_path
         else:
-            print("Unable to find cl.exe; compilation will probably fail.")
+            print("Unable to find cl.exe; compilation will probably fail.", file=sys.stderr)
 
 exllama_ext = load(
     name = extension_name,


### PR DESCRIPTION
These outputs are problematic when piping output to other programs.

"where" writes some unhelpful stuff to stderr/stdout "`INFO: Could not find files for the given pattern(s).` so this quiets that.
Put the "injected compiler path" behind the verbose flag.
The failure to find cl.exe message is now written to stderr to avoid having it unintentionally redirected.
