### PR TITLE
elapsed can be 0 for prompt processing on windows

### DIFF
--- a/webui/session.py
+++ b/webui/session.py
@@ -615,7 +615,8 @@ class Session:
             end_time = time.time()
             elapsed = end_time - begin_time
             new_tokens = context.shape[-1] - reused
-            print(f"Prompt processed in {elapsed:.2f} seconds, {new_tokens} new tokens, {(new_tokens / elapsed):.2f} tokens/second:")
+            token_rate = 0 if elapsed == 0 else (new_tokens / elapsed)
+            print(f"Prompt processed in {elapsed:.2f} seconds, {new_tokens} new tokens, {token_rate:.2f} tokens/second:")
 
         begin_time = time.time()
         total_tokens = [0]
@@ -692,8 +693,9 @@ class Session:
 
         end_time = time.time()
         elapsed = end_time - begin_time
+        token_rate = 0 if elapsed == 0 else (total_tokens[0] / elapsed)
 
-        print(f"Response generated in {elapsed:.2} seconds, {total_tokens[0]} tokens, {(total_tokens[0] / elapsed):.2f} tokens/second:")
+        print(f"Response generated in {elapsed:.2} seconds, {total_tokens[0]} tokens, {token_rate:.2f} tokens/second:")
 
         self.save()
 


### PR DESCRIPTION
Timer precision on windows can be wonky.

When trying to redo a response (deleting it and submitting an empty prompt)
It can finish fast enough that it is lower than the precision of time.time().
time.time() is not supposed to have 16ms precision anymore on windows but for some reason it is on my install, which may be true for other windows users.

I'm pretty sure this can't happen with the response generation time but the symmetry is nice.
