### PR TITLE
Fix AttributeError: 'torch.device' object has no attribute 'startswith' when using gpu_peer_fix.

### DIFF
--- a/model.py
+++ b/model.py
@@ -621,7 +621,7 @@ def _move_tensor(tensor, new_device, name, config):
     device = str(tensor.device)
     if device == new_device: return tensor
     if config.gpu_peer_fix:
-        if device.startswith("cuda:") and new_device.startswith("cuda:"):
+        if str(device).startswith("cuda:") and str(new_device).startswith("cuda:"):
             tensor = tensor.to("cpu")
     return tensor.to(new_device)
 


### PR DESCRIPTION
Fix an issue after https://github.com/turboderp/exllama/commit/15035aa2ac686d883cc4b5350cc7152dd2bd893b commit when using more than 1 GPU and enabling gpu peer fix.

```
  File "F:\ChatIAs\oobabooga\text-generation-webui\repositories\exllama\model.py", line 872, in forward
    logits = _move_tensor(logits, output_device, "logits", self.config)
  File "F:\ChatIAs\oobabooga\text-generation-webui\repositories\exllama\model.py", line 624, in _move_tensor
    if device.startswith("cuda:") and new_device.startswith("cuda:"):
AttributeError: 'torch.device' object has no attribute 'startswith'
```

Fixes https://github.com/oobabooga/text-generation-webui/pull/2803 (exllama_hf) on oobabooga text-generation-webui.
Also should fix normal exllama on ooba when using multi GPU.