### PR TITLE
Fix download_dataset and perplexity wrt to downloaded datasets on Windows

### DIFF
--- a/datasets/download_datasets.py
+++ b/datasets/download_datasets.py
@@ -11,7 +11,7 @@ def download_hf(filename, dataset, subset, split, key, div):
     hf_dataset = load_dataset(dataset, subset, split = split)
     data = div.join(hf_dataset[key])
 
-    with open(filename, "w") as f:
+    with open(filename, "w", encoding="utf-8") as f:
         f.write(data)
 
 download_hf("wikitext2.txt", "wikitext", "wikitext-2-raw-v1", "test", "text", "\n\n")

--- a/perplexity.py
+++ b/perplexity.py
@@ -62,7 +62,7 @@ class Perplexity:
                         self.dataset_chunks.append(chunk)
         # Raw Text
         else:
-            with open(dataset_path) as f:
+            with open(dataset_path, encoding="utf-8") as f:
                 text = f.read()
 
             tokens = self._tokenize(text)


### PR DESCRIPTION
python on windows has some bad legacy behavior around read/write of text files and tries to encode non-ascii text using cp1252 instead of utf-8. [PEP-597](https://peps.python.org/pep-0597/)
(This causes the read/write to fail with an encoding error)

This change explicitly sets the encoding to match how it behaves by default on linux/osx.

The other file reads are either binary or ascii and don't need the change.