### PR TITLE
(Experimental) Add support to NTK RoPE scaling

### DIFF
--- a/model.py
+++ b/model.py
@@ -72,13 +72,10 @@ class ExLlamaConfig:
         self.max_input_len = 2048  # Maximum length of input IDs in a single forward pass. Sequences longer than this will be processed in multiple steps
         self.max_attention_size = 2048**2  # Sequences will be processed in chunks to keep the size of the attention weights matrix <= this
         self.compress_pos_emb = 1.0  # Increase to compress positional embeddings applied to sequence
-        self.alpha_value = 1.0 # Similar to RoPE, higher is more perplex but more ctx
+        self.alpha_value = 1.0 # Alpha value for NTK RoPE scaling. For now, the value has to be set manually, since from the parameters, the setting doesn't seem to apply.
         self.gpu_peer_fix = False # Apparently Torch can have problems transferring tensors directly one GPU to another sometimes. Enable this to expliticly move tensors via system RAM instead, where needed
         self.auto_map = None  # List of floats with memory allocation in GB, per CUDA device, overrides device_map
-
         self.rotary_embedding_base = self.rotary_embedding_base * self.alpha_value ** (self.head_dim / (self.head_dim-2))
-
-
         # Tuning
 
         self.matmul_recons_thd = 8

--- a/model.py
+++ b/model.py
@@ -72,7 +72,7 @@ class ExLlamaConfig:
         self.max_input_len = 2048  # Maximum length of input IDs in a single forward pass. Sequences longer than this will be processed in multiple steps
         self.max_attention_size = 2048**2  # Sequences will be processed in chunks to keep the size of the attention weights matrix <= this
         self.compress_pos_emb = 1.0  # Increase to compress positional embeddings applied to sequence
-        self.alpha_value = 1.0 # Alpha value for NTK RoPE scaling. For now, the value has to be set manually, since from the parameters, the setting doesn't seem to apply.
+        self.alpha_value = 1.0 # Alpha value for NTK RoPE scaling. Similar to compress_pos_emb, higher values increaste ctx but add Perplexity.
         self.gpu_peer_fix = False # Apparently Torch can have problems transferring tensors directly one GPU to another sometimes. Enable this to expliticly move tensors via system RAM instead, where needed
         self.auto_map = None  # List of floats with memory allocation in GB, per CUDA device, overrides device_map
         self.rotary_embedding_base = self.rotary_embedding_base * self.alpha_value ** (self.head_dim / (self.head_dim-2))
@@ -110,6 +110,8 @@ class ExLlamaConfig:
         if map_string is None: self.auto_map = None
         else: self.auto_map = [float(alloc) for alloc in map_string.split(",")]
 
+    def calculate_rotary_embedding_base(self):
+        self.rotary_embedding_base = self.rotary_embedding_base * self.alpha_value ** (self.head_dim / (self.head_dim-2))
 
 # 4-bit linear layer implementation
 

--- a/model.py
+++ b/model.py
@@ -72,8 +72,12 @@ class ExLlamaConfig:
         self.max_input_len = 2048  # Maximum length of input IDs in a single forward pass. Sequences longer than this will be processed in multiple steps
         self.max_attention_size = 2048**2  # Sequences will be processed in chunks to keep the size of the attention weights matrix <= this
         self.compress_pos_emb = 1.0  # Increase to compress positional embeddings applied to sequence
+        self.alpha_value = 1.0 # Similar to RoPE, higher is more perplex but more ctx
         self.gpu_peer_fix = False # Apparently Torch can have problems transferring tensors directly one GPU to another sometimes. Enable this to expliticly move tensors via system RAM instead, where needed
         self.auto_map = None  # List of floats with memory allocation in GB, per CUDA device, overrides device_map
+
+        self.rotary_embedding_base = self.rotary_embedding_base * self.alpha_value ** (self.head_dim / (self.head_dim-2))
+
 
         # Tuning
 

--- a/model.py
+++ b/model.py
@@ -75,7 +75,6 @@ class ExLlamaConfig:
         self.alpha_value = 1.0 # Alpha value for NTK RoPE scaling. Similar to compress_pos_emb, higher values increaste ctx but add Perplexity.
         self.gpu_peer_fix = False # Apparently Torch can have problems transferring tensors directly one GPU to another sometimes. Enable this to expliticly move tensors via system RAM instead, where needed
         self.auto_map = None  # List of floats with memory allocation in GB, per CUDA device, overrides device_map
-        self.rotary_embedding_base = self.rotary_embedding_base * self.alpha_value ** (self.head_dim / (self.head_dim-2))
         # Tuning
 
         self.matmul_recons_thd = 8

--- a/model_init.py
+++ b/model_init.py
@@ -110,6 +110,7 @@ def make_config(args):
     config.set_auto_map(args.gpu_split)
     config.gpu_peer_fix = args.gpu_peer_fix
     config.alpha_value = args.alpha
+    config.calculate_rotary_embedding_base()
 
     config.matmul_recons_thd = args.matmul_recons_thd
     config.fused_mlp_thd = args.fused_mlp_thd

--- a/model_init.py
+++ b/model_init.py
@@ -13,6 +13,7 @@ def add_args(parser):
     parser.add_argument("-gs", "--gpu_split", type = str, help = "Comma-separated list of VRAM (in GB) to use per GPU device for model layers, e.g. -gs 20,7,7")
     parser.add_argument("-l", "--length", type = int, help = "Maximum sequence length", default = 2048)
     parser.add_argument("-cpe", "--compress_pos_emb", type = float, help = "Compression factor for positional embeddings", default = 1.0)
+    parser.add_argument("-a", "--alpha", type = float, help = "alpha for context size extension via embedding extension", default = 1.0)
 
     parser.add_argument("-gpfix", "--gpu_peer_fix", action = "store_true", help = "Prevent direct copies of data between GPUs")
 
@@ -79,6 +80,9 @@ def print_options(args, extra_options = None):
     if args.compress_pos_emb != 1.0:
         print(f" -- RoPE compression factor: {args.compress_pos_emb}")
 
+    if args.alpha != 1.0:
+        print(f" -- RoPE alpha factor: {args.alpha}")
+
     print(f" -- Tuning:")
     print(f" -- --matmul_recons_thd: {args.matmul_recons_thd}" + (" (disabled)" if args.matmul_recons_thd == 0 else ""))
     print(f" -- --fused_mlp_thd: {args.fused_mlp_thd}" + (" (disabled)" if args.fused_mlp_thd == 0 else ""))
@@ -105,6 +109,7 @@ def make_config(args):
     config.compress_pos_emb = args.compress_pos_emb
     config.set_auto_map(args.gpu_split)
     config.gpu_peer_fix = args.gpu_peer_fix
+    config.alpha_value = args.alpha
 
     config.matmul_recons_thd = args.matmul_recons_thd
     config.fused_mlp_thd = args.fused_mlp_thd


### PR DESCRIPTION
This adds support for the new NTK RoPE scaling, mentioned in https://github.com/turboderp/exllama/issues/115.

"According to this post, this is a method of rope scaling that result in less perplexity loss and a bigger possible scaling:
https://www.reddit.com/r/LocalLLaMA/comments/14lz7j5/ntkaware_scaled_rope_allows_llama_models_to_have/"

Adds the parameter "a", "alpha", which is used when loading a model with "-a"

Tested on 65B models at 4K context, with 48GB VRAM (2x24) using gs 16,20

![image](https://github.com/turboderp/exllama/assets/19153797/9253908b-76ea-4141-a6a2-8dbcc0b327c9)

Perplexity:
For tulu-30B-GPTQ (non-SuperHOT)
* Perplexity at 2048 ctx (no compress_pos_emb, no alpha RoPE): 5.2153
* Perplexity at 8192 ctx, compress_pos_emb = 4: 10.0813
* Perplexity at 8192 ctx, alpha  = 4: 5.3534
* Perplexity at 8192 ctx, compress_pos_emb = 4, alpha  = 4: 15.4406

For Tulu-30B-SuperHOT-8K-4bit-32g:
* Perplexity at 2048 ctx (compress_pos_emb = 1, no alpha RoPE): 53.2788 (Basically, for <2048 ctx don't use SuperHOT models)
* Perplexity at 8192 ctx, compress_pos_emb = 4: 5.8166
* Perplexity at 8192 ctx, alpha  = 4: 7.5073
* Perplexity at 8192 ctx, compress_pos_emb = 4, alpha  = 4: 6.0903