### PR TITLE
Fix broken directive when compiling with HIP

### DIFF
--- a/exllama_ext/cuda_func/q4_matmul.cu
+++ b/exllama_ext/cuda_func/q4_matmul.cu
@@ -242,7 +242,7 @@ void q4_matmul_recons_cuda
     }
 
     w->reconstruct(buffers->temp_dq);
-#if __CUDA_ARCH__ < 700
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700
     const float alpha = 1.0f;
     const float beta = no_zero ? 1.0f : 0.0f;
     cublasSgemmEx(handle, CUBLAS_OP_N, CUBLAS_OP_N, width, height, dim, &alpha, buffers->temp_dq, CUDA_R_16F, width,


### PR DESCRIPTION
Commit 088e9d3 (Fix for pascal generation (#123), 2023-07-01) added a conditional directive but didn't check if the identifier was defined.

I tried to see if `cublasSgemmEx` was also faster on my GPU, but `hipblasSgemmEx` is not implemented yet.

Please take care when accepting PR, someone that know how to fix stuff may not see that it's broken for a while, during that time many users suffer with broken software.  It might be useful to setup CI to check that ExLlama still work on all supported platforms before merging patch.