### PR TITLE
Setup package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 exllama_sessions
 models
+exllama_lib
+*.egg-info
+__pycache__/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+exllama_lib
+*.egg-info
+__pycache__/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+exllama_sessions
+models
 exllama_lib
 *.egg-info
 __pycache__/*

--- a/cuda_ext.py
+++ b/cuda_ext.py
@@ -8,6 +8,10 @@ import platform
 
 library_dir = os.path.dirname(os.path.abspath(__file__))
 extension_name = "exllama_ext"
+library_prefix = ""
+if "site-packages" in library_dir:
+    library_prefix = "exllama_lib"
+
 verbose = False
 
 # another kludge to get things compiling in Windows
@@ -43,19 +47,19 @@ if windows:
 exllama_ext = load(
     name = extension_name,
     sources = [
-        os.path.join(library_dir, "exllama_ext/exllama_ext.cpp"),
-        os.path.join(library_dir, "exllama_ext/cuda_buffers.cu"),
-        os.path.join(library_dir, "exllama_ext/cuda_func/q4_matrix.cu"),
-        os.path.join(library_dir, "exllama_ext/cuda_func/q4_matmul.cu"),
-        os.path.join(library_dir, "exllama_ext/cuda_func/column_remap.cu"),
-        os.path.join(library_dir, "exllama_ext/cuda_func/rms_norm.cu"),
-        os.path.join(library_dir, "exllama_ext/cuda_func/rope.cu"),
-        os.path.join(library_dir, "exllama_ext/cuda_func/half_matmul.cu"),
-        os.path.join(library_dir, "exllama_ext/cuda_func/q4_attn.cu"),
-        os.path.join(library_dir, "exllama_ext/cuda_func/q4_mlp.cu"),
-        os.path.join(library_dir, "exllama_ext/cpu_func/rep_penalty.cpp")
+        os.path.join(library_dir, os.path.join(library_prefix, extension_name, "exllama_ext.cpp")),
+        os.path.join(library_dir, os.path.join(library_prefix, extension_name, "cuda_buffers.cu")),
+        os.path.join(library_dir, os.path.join(library_prefix, extension_name, "cuda_func/q4_matrix.cu")),
+        os.path.join(library_dir, os.path.join(library_prefix, extension_name, "cuda_func/q4_matmul.cu")),
+        os.path.join(library_dir, os.path.join(library_prefix, extension_name, "cuda_func/column_remap.cu")),
+        os.path.join(library_dir, os.path.join(library_prefix, extension_name, "cuda_func/rms_norm.cu")),
+        os.path.join(library_dir, os.path.join(library_prefix, extension_name, "cuda_func/rope.cu")),
+        os.path.join(library_dir, os.path.join(library_prefix, extension_name, "cuda_func/half_matmul.cu")),
+        os.path.join(library_dir, os.path.join(library_prefix, extension_name, "cuda_func/q4_attn.cu")),
+        os.path.join(library_dir, os.path.join(library_prefix, extension_name, "cuda_func/q4_mlp.cu")),
+        os.path.join(library_dir, os.path.join(library_prefix, extension_name, "cpu_func/rep_penalty.cpp"))
     ],
-    extra_include_paths = [os.path.join(library_dir, "exllama_ext")],
+    extra_include_paths = [os.path.join(library_dir, extension_name)],
     verbose = verbose,
     extra_ldflags = (["cublas.lib"] + ([f"/LIBPATH:{os.path.join(sys.base_prefix, 'libs')}"] if sys.base_prefix != sys.prefix else [])) if windows else [],
     extra_cuda_cflags = ["-lineinfo"] + (["-U__HIP_NO_HALF_CONVERSIONS__", "-O3"] if torch.version.hip else []),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
+-f https://download.pytorch.org/whl/nightly/cu118
 torch>=2.0.1
 safetensors==0.3.1
 sentencepiece>=0.1.97
 ninja==1.11.1
+torch>=2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 -f https://download.pytorch.org/whl/nightly/cu118
-torch>=2.0.1
 safetensors==0.3.1
 sentencepiece>=0.1.97
 ninja==1.11.1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import codecs
+from setuptools import setup
+import shutil
+import pathlib
+
+def read(fname):
+    file_path = os.path.join(os.path.dirname(__file__), fname)
+    lines = codecs.open(file_path, encoding="utf-8").readlines()
+    requirements = []
+    dependency_links = []
+    for line in lines:
+        if line.startswith("-f"):
+            dependency_links.append(line.split("-f")[1])
+        else:
+            requirements.append(line)
+    return requirements, dependency_links
+
+requirements, dependency_links = read("requirements.txt")
+
+print("Creating temporary package directory")
+
+package_target_dir="exllama_lib"
+extension_dir = "exllama_ext"
+
+# Clean state before trying to package again
+try:
+    shutil.rmtree(package_target_dir)
+except FileNotFoundError:
+    pass
+
+os.makedirs(package_target_dir)
+
+exported_modules = [
+        "cuda_ext",
+        "lora",
+        "generator",
+        "model_init",
+        "model",
+        "perplexity",
+        "tokenizer"
+]
+
+for exported_file in exported_modules:
+    python_file = f"{exported_file}.py"
+    shutil.copyfile(python_file, os.path.join(package_target_dir, python_file))
+
+shutil.copytree(extension_dir, os.path.join(package_target_dir, extension_dir))
+pathlib.Path(os.path.join(package_target_dir, "__init__.py")).touch(exist_ok=True)
+
+def package_files(directory):
+    # Recursive copy of packaged data dir
+    # Originally from: https://stackoverflow.com/a/36693250/8628527
+    paths = []
+    for (path, _, filenames) in os.walk(directory):
+        for filename in filenames:
+            paths.append(os.path.join('..', path, filename))
+    return paths
+
+extra_files = package_files(os.path.join(package_target_dir, extension_dir))
+
+
+setup(
+    name="exllama_lib",
+    version="0.1.0",
+    author="turboderp",
+    author_email="<not provided>",
+    maintainer="turboderp",
+    maintainer_email="<not provided>",
+    license="MIT",
+    url="https://github.com/turboderp/exllama",
+    description="Memory efficient implementation of llama inference.",
+    python_requires=">=3.8",
+    install_requires=requirements,
+    dependency_links=dependency_links,
+    packages=[package_target_dir],
+    package_data={
+        package_target_dir: extra_files
+    },
+    py_modules=exported_modules,
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Framework :: Pytest",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Testing",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
+        "Operating System :: OS Independent",
+        "License :: OSI Approved :: MIT License",
+    ]
+)

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     license="MIT",
     url="https://github.com/turboderp/exllama",
     description="Memory efficient implementation of llama inference.",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=requirements,
     dependency_links=dependency_links,
     packages=[package_target_dir],


### PR DESCRIPTION
Supports installing `exllama` as a package.

Example usage:
```
 pip install 'exllama_lib @ git+https://github.com/paolorechia/exllama@setup-package'
```

EDIT:
Worth explaining how to use the installed package. Since the installation setup creates a temporary `exllama_lib` to package `exllama`, the package also has this name, and can be imported as following:

```
from exllama_lib.model import ExLlama, ExLlamaCache, ExLlamaConfig
from exllama_lib.tokenizer import ExLlamaTokenizer
from exllama_lib.generator import ExLlamaGenerator
```