### PR TITLE
Fix half2 with HIP

### DIFF
--- a/exllama_ext/cuda_func/half_matmul.cu
+++ b/exllama_ext/cuda_func/half_matmul.cu
@@ -41,8 +41,8 @@ __global__ void half_matmul_kernel
     for (int k = k0; k < k0 + BLOCKSIZE / 2; k++)
     {
         half2 x_item = *x_ptr++;
-        half2 x_item_0 = __half2half2(x_item.x);
-        half2 x_item_1 = __half2half2(x_item.y);
+        half2 x_item_0 = __low2half2(x_item);
+        half2 x_item_1 = __high2half2(x_item);
         half2 w_item_0 = *w_ptr; w_ptr += w_.width / 2;
         half2 w_item_1 = *w_ptr; w_ptr += w_.width / 2;
         acc = __hfma2(x_item_0, w_item_0, acc);
@@ -184,7 +184,7 @@ __global__ void half_matmul_small_kernel
             r = __hfma2(x_23, w_23, r);
         }
 
-        half rh = __hadd(r.x, r.y);
+        half rh = __hadd(__low2half(r), __high2half(r));
 
         __shared__ half accum[MAX_DIM_SMALL / S_BLOCKSIZE][S_THREADS_X];
         accum[threadIdx.y][threadIdx.x] = rh;

--- a/exllama_ext/cuda_func/q4_matmul.cu
+++ b/exllama_ext/cuda_func/q4_matmul.cu
@@ -131,7 +131,7 @@ __global__ void q4_matmul_kernel
 
     if constexpr (use_half2)
     {
-        half result = __hadd(acc.x, acc.y);
+        half result = __hadd(__low2half(acc), __high2half(acc));
         atomicAdd(out_.item_ptr(x_row, w_column), result);
     }
     else

--- a/exllama_ext/cuda_func/rms_norm.cu
+++ b/exllama_ext/cuda_func/rms_norm.cu
@@ -50,8 +50,8 @@ __global__ void rms_norm_row_product_kernel
         for (int k = 0; k < BLOCKSIZE_X / 2; k++)
         {
             half2 x2 = *x_ptr++;
-            float m0 = __half2float(x2.x);
-            float m1 = __half2float(x2.y);
+            float m0 = __low2float(x2);
+            float m1 = __high2float(x2);
             acc = fma(m0, m0, acc);
             acc = fma(m1, m1, acc);
         }

--- a/exllama_ext/hip_compat.cuh
+++ b/exllama_ext/hip_compat.cuh
@@ -8,8 +8,8 @@ __device__ __forceinline__ __half __compat_hrcp(__half x) {
 }
 
 __device__ __forceinline__ __half2 __compat_h2rcp(__half2 x) {
-    return _Float16_2{static_cast<_Float16>(__builtin_amdgcn_rcph(x.x)),
-        static_cast<_Float16>(__builtin_amdgcn_rcph(x.y))};
+    return __half2_raw{__compat_hrcp(__low2half(x)),
+        __compat_hrcp(__high2half(x))};
 }
 
 #define hrcp __compat_hrcp


### PR DESCRIPTION
The current version of CUDA allows you to access the component halfs of half2 through half2.x and half2.y, but in HIP x and y are unsigned shorts and not half or _float16. This replaces accessing those variables with intrinsic functions.

With the changes I can use --force_half2 and still get sensible text with my AMD GPU.


