### PR TITLE
Tokenzier special chars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ignore __pycache__ folder
+__pycache__/

--- a/tokenizer.py
+++ b/tokenizer.py
@@ -18,8 +18,6 @@ class ExLlamaTokenizer:
         self.pad_token_id = 0  # self.tokenizer.pad_id()
         self.newline_token_id = 13
 
-        print(f"unknown token id: {self.unk_token_id}")
-
         self.special_characters = [(self.bos_token, self.bos_token_id), (self.eos_token, self.eos_token_id), (self.unk_token, self.unk_token_id)] # for tokenzier encoding
 
     # Encode string

--- a/tokenizer.py
+++ b/tokenizer.py
@@ -20,7 +20,7 @@ class ExLlamaTokenizer:
 
     # Encode string
 
-    def encode(self, text, return_mask = False, max_seq_len = 2048, pad_eos = False, pad_bos = False):
+    def encode(self, text, return_mask = False, max_seq_len = 2048, add_bos = False, add_eos = False):
 
         if isinstance(text, list):
 
@@ -30,9 +30,9 @@ class ExLlamaTokenizer:
 
             # pad bos and eos
 
-            if pad_bos:
+            if add_bos:
                 for ids in list_ids: ids.insert(0, self.bos_token_id)
-            if pad_eos:
+            if add_eos:
                 for ids in list_ids: ids.append(self.eos_token_id)
 
             max_length = max([len(ids) for ids in list_ids])

--- a/tokenizer.py
+++ b/tokenizer.py
@@ -12,15 +12,19 @@ class ExLlamaTokenizer:
         self.unk_token = "<unk>"
         self.bos_token = "<s>"
         self.eos_token = "</s>"
-        self.unk_token_id = self.tokenizer.unk_id()
+        self.unk_token_id = self.tokenizer.unk_id() # is the same as pad token id...
         self.eos_token_id = self.tokenizer.eos_id()
         self.bos_token_id = self.tokenizer.bos_id()
         self.pad_token_id = 0  # self.tokenizer.pad_id()
         self.newline_token_id = 13
 
+        print(f"unknown token id: {self.unk_token_id}")
+
+        self.special_characters = [(self.bos_token, self.bos_token_id), (self.eos_token, self.eos_token_id), (self.unk_token, self.unk_token_id)] # for tokenzier encoding
+
     # Encode string
 
-    def encode(self, text, return_mask = False, max_seq_len = 2048, add_bos = False, add_eos = False):
+    def encode(self, text, return_mask = False, max_seq_len = 2048, add_bos = False, add_eos = False, encode_special_characters = False):
 
         if isinstance(text, list):
 
@@ -61,8 +65,34 @@ class ExLlamaTokenizer:
         else:
 
             # text is a single string
+            split_text = [text]
 
-            ids = self.tokenizer.EncodeAsIds(text)
+            # look for special characters
+            if encode_special_characters:
+                for special_character, special_token_id in self.special_characters:
+                    temp_text = []
+                    for segment in split_text:
+                        if isinstance(segment, str) and special_character in segment:
+                            print("found special character: " + special_character)
+                            # for each special character, append the text before the special character, then append the special character ID, then the rest of the text
+                            parts = segment.split(special_character)
+                            new_parts = []
+                            for i, part in enumerate(parts):
+                                new_parts.append(part)
+                                if i < len(parts) - 1:  # add the special token id between parts, but not after the last part
+                                    new_parts.append(special_token_id)
+                            temp_text.extend(new_parts)
+                        else:
+                            temp_text.append(segment)
+                    split_text = temp_text
+
+            ids = []
+
+            for text_chunk in split_text:
+                if isinstance(text_chunk, str):
+                    ids += self.tokenizer.EncodeAsIds(text_chunk)
+                else:
+                    ids.append(text_chunk)
 
             # pad bos and eos
 
@@ -78,25 +108,68 @@ class ExLlamaTokenizer:
             else:
                 return stacked_ids
 
-    def decode(self, ids):
+    def decode(self, ids, decode_special_characters=False):
+        special_ids = {id_: char for char, id_ in self.special_characters}  # create a lookup dictionary
 
         if ids.dim() > 1:
-
             texts = []
             for i in range(ids.shape[0]):
                 seq = ids[i].tolist()
                 seq = [t for t in seq if t != self.pad_token_id]
-                if self.eos_token_id in seq: seq = seq[:seq.index(self.eos_token_id)]
-                texts.append(self.tokenizer.Decode(seq))
+
+                if decode_special_characters:
+                    text_parts = []
+                    normal_ids = []  # list of lists
+                    current_normal_ids = []  # current list of normal IDs
+                    for idx, id_ in enumerate(seq):
+                        if id_ in special_ids:
+                            # Save the current list of normal IDs, then start a new one
+                            normal_ids.append(current_normal_ids)
+                            current_normal_ids = []
+                            # Store special token as a string
+                            text_parts.append(special_ids[id_])
+                        else:
+                            current_normal_ids.append(id_)
+                    normal_ids.append(current_normal_ids)  # save the last segment of normal IDs
+                    
+                    decoded_segments = [self.tokenizer.Decode(segment) for segment in normal_ids]
+                    for idx, decoded_segment in enumerate(decoded_segments):
+                        text_parts.insert(2*idx, decoded_segment)
+                    
+                    texts.append("".join(text_parts))
+                else:
+                    if self.eos_token_id in seq:  # to not mess up special char decoding
+                        seq = seq[:seq.index(self.eos_token_id)]
+
             return texts
 
         else:
-
             ids = ids.tolist()
-            text = self.tokenizer.Decode(ids)
+
+            if decode_special_characters:
+                text_parts = []
+                normal_ids = []  # list of lists
+                current_normal_ids = []  # current list of normal IDs
+                for idx, id_ in enumerate(ids):
+                    if id_ in special_ids:
+                        # Save the current list of normal IDs, then start a new one
+                        normal_ids.append(current_normal_ids)
+                        current_normal_ids = []
+                        # Store special token as a string
+                        text_parts.append(special_ids[id_])
+                    else:
+                        current_normal_ids.append(id_)
+                normal_ids.append(current_normal_ids)  # save the last segment of normal IDs
+                
+                decoded_segments = [self.tokenizer.Decode(segment) for segment in normal_ids]
+                for idx, decoded_segment in enumerate(decoded_segments):
+                    text_parts.insert(2*idx, decoded_segment)
+                
+                text = "".join(text_parts)
+            
             return text
 
-    def num_tokens(self, text):
+    def num_tokens(self, text): # TODO
 
         ids = self.tokenizer.Encode(text)
         return len(ids)

--- a/tokenizer.py
+++ b/tokenizer.py
@@ -106,9 +106,11 @@ class ExLlamaTokenizer:
                 return stacked_ids
 
     def decode(self, ids, decode_special_characters=False):
+        
         special_ids = {id_: char for char, id_ in self.special_characters}  # create a lookup dictionary
 
         if ids.dim() > 1:
+            
             texts = []
             for i in range(ids.shape[0]):
                 seq = ids[i].tolist()
@@ -141,9 +143,11 @@ class ExLlamaTokenizer:
             return texts
 
         else:
+            
             ids = ids.tolist()
 
             if decode_special_characters:
+                
                 text_parts = []
                 normal_ids = []  # list of lists
                 current_normal_ids = []  # current list of normal IDs
@@ -163,15 +167,17 @@ class ExLlamaTokenizer:
                     text_parts.insert(2*idx, decoded_segment)
                 
                 text = "".join(text_parts)
-            
+
             return text
 
     def num_tokens(self, text, encode_special_characters = False):
-        ids = []
-
+        
         if encode_special_characters:
+            
             ids = self.encode(text, encode_special_characters = True)
             return ids.size(1)
+        
         else:
+            
             ids = self.tokenizer.Encode(text)
             return len(ids)

--- a/tokenizer.py
+++ b/tokenizer.py
@@ -19,15 +19,29 @@ class ExLlamaTokenizer:
         self.newline_token_id = 13
 
 
+        print(self.encode("hello world"))
+        print(self.encode("hello world", pad_bos=True, pad_eos=True))
+
+        print(self.encode(["hello world", "hello world", "hello world"], pad_bos=False, pad_eos=False))
+        print(self.encode(["hello world", "hello world", "hello world"], pad_bos=True, pad_eos=True))
+
     # Encode string
 
-    def encode(self, text, return_mask = False, max_seq_len = 2048):
+    def encode(self, text, return_mask = False, max_seq_len = 2048, pad_eos = False, pad_bos = False):
 
         if isinstance(text, list):
 
             # text is a list of strings
 
             list_ids = self.tokenizer.EncodeAsIds(text)
+
+            # pad bos and eos
+
+            if pad_bos:
+                for ids in list_ids: ids.insert(0, self.bos_token_id)
+            if pad_eos:
+                for ids in list_ids: ids.append(self.eos_token_id)
+
             max_length = max([len(ids) for ids in list_ids])
 
             needs_mask = False
@@ -56,6 +70,14 @@ class ExLlamaTokenizer:
             # text is a single string
 
             ids = self.tokenizer.EncodeAsIds(text)
+
+            # pad bos and eos
+            
+            if pad_bos:
+              ids = [self.bos_token_id] + ids
+            if pad_eos:
+              ids = ids + [self.eos_token_id]
+
             stacked_ids = torch.tensor(ids).unsqueeze(0)
 
             if return_mask:

--- a/tokenizer.py
+++ b/tokenizer.py
@@ -71,7 +71,6 @@ class ExLlamaTokenizer:
                     temp_text = []
                     for segment in split_text:
                         if isinstance(segment, str) and special_character in segment:
-                            print("found special character: " + special_character)
                             # for each special character, append the text before the special character, then append the special character ID, then the rest of the text
                             parts = segment.split(special_character)
                             new_parts = []
@@ -167,7 +166,12 @@ class ExLlamaTokenizer:
             
             return text
 
-    def num_tokens(self, text): # TODO
+    def num_tokens(self, text, encode_special_characters = False):
+        ids = []
 
-        ids = self.tokenizer.Encode(text)
-        return len(ids)
+        if encode_special_characters:
+            ids = self.encode(text, encode_special_characters = True)
+            return ids.size(1)
+        else:
+            ids = self.tokenizer.Encode(text)
+            return len(ids)

--- a/tokenizer.py
+++ b/tokenizer.py
@@ -66,9 +66,9 @@ class ExLlamaTokenizer:
 
             # pad bos and eos
 
-            if pad_bos:
+            if add_bos:
               ids = [self.bos_token_id] + ids
-            if pad_eos:
+            if add_eos:
               ids = ids + [self.eos_token_id]
 
             stacked_ids = torch.tensor(ids).unsqueeze(0)

--- a/tokenizer.py
+++ b/tokenizer.py
@@ -18,13 +18,6 @@ class ExLlamaTokenizer:
         self.pad_token_id = 0  # self.tokenizer.pad_id()
         self.newline_token_id = 13
 
-
-        print(self.encode("hello world"))
-        print(self.encode("hello world", pad_bos=True, pad_eos=True))
-
-        print(self.encode(["hello world", "hello world", "hello world"], pad_bos=False, pad_eos=False))
-        print(self.encode(["hello world", "hello world", "hello world"], pad_bos=True, pad_eos=True))
-
     # Encode string
 
     def encode(self, text, return_mask = False, max_seq_len = 2048, pad_eos = False, pad_bos = False):
@@ -72,7 +65,7 @@ class ExLlamaTokenizer:
             ids = self.tokenizer.EncodeAsIds(text)
 
             # pad bos and eos
-            
+
             if pad_bos:
               ids = [self.bos_token_id] + ids
             if pad_eos:


### PR DESCRIPTION
https://github.com/turboderp/exllama/pull/195#issuecomment-1649736282
Hello! :) Per your request:
> I.e. you should just be able to add <s> and </s> at arbitrary places in the input string, as well as any other custom special tokens any given model requires. Ideally it would work when decoding as well.

I added your functionalities just like you described. One can now choose to encode/decode special characters.


This PR is based or rather dependent on the other PR ( #195 ) (because locally I need both and I don't know GitHub well enough to merge both)

Example:

The string: `<s><s>Hello</s><unk> <s>World</s></s>`
encodes to: `tensor([[    1,     1, 15043,     2,     0,   259,     1,  2787,     2,     2]])` (I verified all IDs manually)

(without encode_special_characters: `tensor([[  529, 29879,  5299, 29879, 29958, 10994,   829, 29879,  5299,  2960,  29958,   529, 29879, 29958, 14058,   829, 29879,  2565, 29879, 29958]])`)

Decoding these IDs results in:
`<s><s>Hello</s> <s>World</s></s>`

Which is correct! (`<unk>` is the same id as the padding token, 0. If you want, I can also include every 0 to be a `<unk>`)

If you want to test and verify, here is the snippet that I put into the tokenizer init for debugging:
```py
        text = "<s><s>Hello</s><unk> <s>World</s></s>"
        print("encoding: " + text)
        print(self.encode(text, encode_special_characters=True))
        print(self.encode([text, text, text, text], encode_special_characters=True))

        ids = self.encode(text, encode_special_characters=True)
        idsb = self.encode([text, text, text, text], encode_special_characters=True)
        print(f"decoding: {self.decode(ids, decode_special_characters=True)}")
        print(f"decoding batch: {self.decode(idsb, decode_special_characters=True)}")
```


I would be happy if you accepted both pull requests and I hope this PR aligns with your intents :)