### PR TITLE
Add example of max seq length configuration

### DIFF
--- a/example_flask.py
+++ b/example_flask.py
@@ -14,6 +14,7 @@ model_path = glob.glob(st_pattern)[0]
 
 config = ExLlamaConfig(model_config_path)               # create config from config.json
 config.model_path = model_path                          # supply path to model weights file
+config.max_seq_len = 2048                               # maximum prompt length
 
 model = ExLlama(config)                                 # create ExLlama instance and load the weights
 print(f"Model loaded: {model_path}")


### PR DESCRIPTION
Add example of max seq length configuration, might be helpful to others to know how to adjust this property since llama 2 works with 4096.