### PR TITLE
Generation uses config.max_seq_len instead of default 2048

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -312,7 +312,7 @@ class ExLlamaGenerator:
 
         self.end_beam_search()
 
-        ids, mask = self.tokenizer.encode(prompt, return_mask = True)
+        ids, mask = self.tokenizer.encode(prompt, return_mask = True, max_seq_len = self.model.config.max_seq_len)
         self.gen_begin(ids, mask = mask)
 
         max_new_tokens = min(max_new_tokens, self.model.config.max_seq_len - ids.shape[1])


### PR DESCRIPTION
The max_seq_len was not used when calling `generator.generate_simple()` making it impossible to use with prompt bigger than 2048 tokens, for example on new Llama 2 that have 4096 context size.