### PR TITLE
Optimize q4_matmul

### DIFF
--- a/exllama_ext/cuda_func/q4_matmul.cu
+++ b/exllama_ext/cuda_func/q4_matmul.cu
@@ -96,14 +96,15 @@ __global__ void q4_matmul_kernel
             {
                 half2 w_scale = w_scales_.item_half2half2(group, w_column);
                 uint32_t w_zero = w_zeros_.item(group, w_column) + 1;
-                dot_product_8(acc, x_cache, w_, k, w_column, w_scale, w_zero, groupsize / 8);
+                acc = dot_product_8(acc, x_cache, w_, k, w_column, w_scale, w_zero, groupsize / 8);
             }
             else
             {
                 half w_scale = w_scales_.item(group, w_column);
                 uint32_t w_zero = w_zeros_.item(group, w_column) + 1;
-                dot_product_8_h(acc_h, x_cache_h, w_, k, w_column, w_scale, w_zero, groupsize / 8);
+                acc_h = dot_product_8_h(acc_h, x_cache_h, w_, k, w_column, w_scale, w_zero, groupsize / 8);
             }
+            __syncthreads();
         }
     }
     else
@@ -124,15 +125,16 @@ __global__ void q4_matmul_kernel
                 int group = k / groupsize;
                 half2 w_scale = w_scales_.item_half2half2(group, w_column);
                 uint32_t w_zero = w_zeros_.item(group, w_column) + 1;
-                dot_product_8(acc, x_cache, w_, k, w_column, w_scale, w_zero, 1);
+                acc = dot_product_8(acc, x_cache, w_, k, w_column, w_scale, w_zero, 1);
             }
             else
             {
                 int group = k / groupsize;
                 half w_scale = w_scales_.item(group, w_column);
                 uint32_t w_zero = w_zeros_.item(group, w_column) + 1;
-                dot_product_8_h(acc_h, x_cache_h, w_, k, w_column, w_scale, w_zero, 1);
+                acc_h = dot_product_8_h(acc_h, x_cache_h, w_, k, w_column, w_scale, w_zero, 1);
             }
+            __syncthreads();
         }
     }
 

--- a/exllama_ext/cuda_func/q4_matmul.cu
+++ b/exllama_ext/cuda_func/q4_matmul.cu
@@ -124,14 +124,14 @@ __global__ void q4_matmul_kernel
                 int group = k / groupsize;
                 half2 w_scale = w_scales_.item_half2half2(group, w_column);
                 uint32_t w_zero = w_zeros_.item(group, w_column) + 1;
-                dot_product_8(acc, x_cache, w_, k, w_column, w_scale, w_zero, groupsize / 8);
+                dot_product_8(acc, x_cache, w_, k, w_column, w_scale, w_zero, 1);
             }
             else
             {
                 int group = k / groupsize;
                 half w_scale = w_scales_.item(group, w_column);
                 uint32_t w_zero = w_zeros_.item(group, w_column) + 1;
-                dot_product_8_h(acc_h, x_cache_h, w_, k, w_column, w_scale, w_zero, groupsize / 8);
+                dot_product_8_h(acc_h, x_cache_h, w_, k, w_column, w_scale, w_zero, 1);
             }
         }
     }

--- a/exllama_ext/cuda_func/q4_matmul.cu
+++ b/exllama_ext/cuda_func/q4_matmul.cu
@@ -44,6 +44,9 @@ __global__ void q4_matmul_kernel
     bool no_zero
 )
 {
+    extern __shared__ half2 x_cache[];
+    half* x_cache_h = (half*)x_cache;
+
     // Start of block
 
     int x_column = block_size_z * blockIdx.z;
@@ -82,21 +85,24 @@ __global__ void q4_matmul_kernel
 
         for (int k = x_column, group = x_column / groupsize; k < x_column + iterations * 8; group++, k += groupsize)
         {
+            for (int i = threadIdx.x; i < groupsize; i += THREADS_X)
+            {
+                if constexpr (use_x_map) x_cache_h[i] = *x_.item_ptr(x_row, x_map[k + i]);
+                else                     x_cache_h[i] = *x_.item_ptr(x_row, k + i);
+            }
+            if constexpr (THREADS_X * THREADS_Y > 32) __syncthreads();
+
             if constexpr (use_half2)
             {
                 half2 w_scale = w_scales_.item_half2half2(group, w_column);
                 uint32_t w_zero = w_zeros_.item(group, w_column) + 1;
-
-                if constexpr (use_x_map) acc = dot_product_8_x_map(acc, x_, x_row, k, w_, k, w_column, w_scale, w_zero, groupsize / 8, x_map);
-                else                     acc = dot_product_8      (acc, x_, x_row, k, w_, k, w_column, w_scale, w_zero, groupsize / 8);
+                dot_product_8(acc, x_cache, w_, k, w_column, w_scale, w_zero, groupsize / 8);
             }
             else
             {
                 half w_scale = w_scales_.item(group, w_column);
                 uint32_t w_zero = w_zeros_.item(group, w_column) + 1;
-
-                if constexpr (use_x_map) acc_h = dot_product_8_x_map_h(acc_h, x_, x_row, k, w_, k, w_column, w_scale, w_zero, groupsize / 8, x_map);
-                else                     acc_h = dot_product_8_h      (acc_h, x_, x_row, k, w_, k, w_column, w_scale, w_zero, groupsize / 8);
+                dot_product_8_h(acc_h, x_cache_h, w_, k, w_column, w_scale, w_zero, groupsize / 8);
             }
         }
     }
@@ -106,23 +112,26 @@ __global__ void q4_matmul_kernel
 
         for (int k = x_column; k < x_column + iterations * 8; k += 8)
         {
+            for (int i = threadIdx.x; i < 8; i += THREADS_X)
+            {
+                if constexpr (use_x_map) x_cache_h[i] = *x_.item_ptr(x_row, x_map[k + i]);
+                else                     x_cache_h[i] = *x_.item_ptr(x_row, k + i);
+            }
+            if constexpr (THREADS_X * THREADS_Y > 32) __syncthreads();
+
             if constexpr (use_half2)
             {
                 int group = k / groupsize;
                 half2 w_scale = w_scales_.item_half2half2(group, w_column);
                 uint32_t w_zero = w_zeros_.item(group, w_column) + 1;
-
-                if constexpr (use_x_map) acc = dot_product_8_x_map(acc, x_, x_row, k, w_, k, w_column, w_scale, w_zero, 1, x_map);
-                else                     acc = dot_product_8      (acc, x_, x_row, k, w_, k, w_column, w_scale, w_zero, 1);
+                dot_product_8(acc, x_cache, w_, k, w_column, w_scale, w_zero, groupsize / 8);
             }
             else
             {
                 int group = k / groupsize;
                 half w_scale = w_scales_.item(group, w_column);
                 uint32_t w_zero = w_zeros_.item(group, w_column) + 1;
-
-                if constexpr (use_x_map) acc_h = dot_product_8_x_map_h(acc_h, x_, x_row, k, w_, k, w_column, w_scale, w_zero, 1, x_map);
-                else                     acc_h = dot_product_8_h      (acc_h, x_, x_row, k, w_, k, w_column, w_scale, w_zero, 1);
+                dot_product_8_h(acc_h, x_cache_h, w_, k, w_column, w_scale, w_zero, groupsize / 8);
             }
         }
     }
@@ -213,7 +222,7 @@ void q4_matmul_cuda
     );
 
     fp_q4_matmul_kernel kernel = q4_matmul_kernel_pick(tuningParams, block_size_z, w->groupsize, x_map);
-    kernel<<<blocks, threads, 0, alt_stream>>> (x_mapped, w->cuda_qweight, out, w->cuda_scales, w->cuda_qzeros, height, dim, width, w->groupsize, block_size_z, x_map, no_zero);
+    kernel<<<blocks, threads, w->groupsize * sizeof(half), alt_stream>>>(x_mapped, w->cuda_qweight, out, w->cuda_scales, w->cuda_qzeros, height, dim, width, w->groupsize, block_size_z, x_map, no_zero);
 }
 
 void q4_matmul_recons_cuda

--- a/exllama_ext/cuda_func/q4_matmul.cu
+++ b/exllama_ext/cuda_func/q4_matmul.cu
@@ -70,8 +70,8 @@ __global__ void q4_matmul_kernel
     if (!no_zero && blockIdx.z == 0 && (threadIdx.x & 1) == 0)
     {
         *((uint32_t*) out_.item_ptr(x_row, w_column)) = 0;
-        __syncthreads();
     }
+    __syncthreads();
 
     // Loop over part of x row (and w column)
 
@@ -90,7 +90,7 @@ __global__ void q4_matmul_kernel
                 if constexpr (use_x_map) x_cache_h[i] = *x_.item_ptr(x_row, x_map[k + i]);
                 else                     x_cache_h[i] = *x_.item_ptr(x_row, k + i);
             }
-            if constexpr (THREADS_X * THREADS_Y > 32) __syncthreads();
+            __syncthreads();
 
             if constexpr (use_half2)
             {
@@ -117,7 +117,7 @@ __global__ void q4_matmul_kernel
                 if constexpr (use_x_map) x_cache_h[i] = *x_.item_ptr(x_row, x_map[k + i]);
                 else                     x_cache_h[i] = *x_.item_ptr(x_row, k + i);
             }
-            if constexpr (THREADS_X * THREADS_Y > 32) __syncthreads();
+            __syncthreads();
 
             if constexpr (use_half2)
             {

--- a/exllama_ext/matrix.cuh
+++ b/exllama_ext/matrix.cuh
@@ -87,9 +87,7 @@ public:
 __device__ __forceinline__ half2 dot_product_8
 (
     const half2 acc,
-    MatrixView_half& h_,
-    const int h_row,
-    const int h_column,                 // divisible by 8
+    const half2* h_ptr,
     MatrixView_q4_column& v_,
     const int v_row,                    // divisible by 8
     const int v_column,
@@ -98,7 +96,6 @@ __device__ __forceinline__ half2 dot_product_8
     const int count
 )
 {
-    const half2* h_ptr = (const half2*) h_.item_ptr(h_row, h_column);
     const uint32_t* v_ptr = (const uint32_t*) v_.item_uint32_ptr(v_row, v_column);
     half2 result = acc;
 
@@ -138,9 +135,7 @@ __device__ __forceinline__ half2 dot_product_8
 __device__ __forceinline__ half dot_product_8_h
 (
     const half acc,
-    MatrixView_half& h_,
-    const int h_row,
-    const int h_column,                 // divisible by 8
+    const half* h_ptr,
     MatrixView_q4_column& v_,
     const int v_row,                    // divisible by 8
     const int v_column,
@@ -149,7 +144,6 @@ __device__ __forceinline__ half dot_product_8_h
     const int count
 )
 {
-    const half* h_ptr = h_.item_ptr(h_row, h_column);
     const uint32_t* v_ptr = (const uint32_t*) v_.item_uint32_ptr(v_row, v_column);
     half result = acc;
 
@@ -174,117 +168,6 @@ __device__ __forceinline__ half dot_product_8_h
         tmp = __hfma(*h_ptr++, v_5, tmp);
         tmp = __hfma(*h_ptr++, v_6, tmp);
         tmp = __hfma(*h_ptr++, v_7, tmp);
-        result = __hfma(v_scale, tmp, result);
-    }
-
-    return result;
-}
-
-// Accumulated dot product of 8-element row vectors in h and quantized column vectors in v, constant zero/scale, with x_map
-
-__device__ __forceinline__ half2 dot_product_8_x_map
-(
-    const half2 acc,
-    MatrixView_half& h_,
-    const int h_row,
-    const int h_column,                 // divisible by 8
-    MatrixView_q4_column& v_,
-    const int v_row,                    // divisible by 8
-    const int v_column,
-    const half2 v_scale_2,
-    const uint32_t v_zero,              // + 1 (!!)
-    const int count,
-    const uint32_t* x_map
-)
-{
-    const half* h_ptr = h_.item_ptr(h_row, 0);
-    const uint32_t* x_map_ptr = x_map + h_column;
-    const uint32_t* v_ptr = (const uint32_t*) v_.item_uint32_ptr(v_row, v_column);
-    half2 result = acc;
-
-    for (int i = 0; i < count; i++)
-    {
-        uint32_t v_read = *v_ptr; v_ptr += v_.width;
-
-        half v_0 = __int2half_rn((int)((v_read      ) & 0x0f) - v_zero);
-        half v_1 = __int2half_rn((int)((v_read >>  4) & 0x0f) - v_zero);
-        half v_2 = __int2half_rn((int)((v_read >>  8) & 0x0f) - v_zero);
-        half v_3 = __int2half_rn((int)((v_read >> 12) & 0x0f) - v_zero);
-        half v_4 = __int2half_rn((int)((v_read >> 16) & 0x0f) - v_zero);
-        half v_5 = __int2half_rn((int)((v_read >> 20) & 0x0f) - v_zero);
-        half v_6 = __int2half_rn((int)((v_read >> 24) & 0x0f) - v_zero);
-        half v_7 = __int2half_rn((int)((v_read >> 28)       ) - v_zero);
-
-        half2 v_01 = __halves2half2(v_0, v_1);
-        half2 v_23 = __halves2half2(v_2, v_3);
-        half2 v_45 = __halves2half2(v_4, v_5);
-        half2 v_67 = __halves2half2(v_6, v_7);
-
-        half h_0 = h_ptr[*x_map_ptr++];
-        half h_1 = h_ptr[*x_map_ptr++];
-        half h_2 = h_ptr[*x_map_ptr++];
-        half h_3 = h_ptr[*x_map_ptr++];
-        half h_4 = h_ptr[*x_map_ptr++];
-        half h_5 = h_ptr[*x_map_ptr++];
-        half h_6 = h_ptr[*x_map_ptr++];
-        half h_7 = h_ptr[*x_map_ptr++];
-
-        half2 h_01 = __halves2half2(h_0, h_1);
-        half2 h_23 = __halves2half2(h_2, h_3);
-        half2 h_45 = __halves2half2(h_4, h_5);
-        half2 h_67 = __halves2half2(h_6, h_7);
-
-        half2 tmp = __hmul2(h_01, v_01);
-        tmp = __hfma2(h_23, v_23, tmp);
-        tmp = __hfma2(h_45, v_45, tmp);
-        tmp = __hfma2(h_67, v_67, tmp);
-        result = __hfma2(v_scale_2, tmp, result);
-    }
-
-    return result;
-}
-
-__device__ __forceinline__ half dot_product_8_x_map_h
-(
-    const half acc,
-    MatrixView_half& h_,
-    const int h_row,
-    const int h_column,                 // divisible by 8
-    MatrixView_q4_column& v_,
-    const int v_row,                    // divisible by 8
-    const int v_column,
-    const half v_scale,
-    const uint32_t v_zero,              // + 1 (!!)
-    const int count,
-    const uint32_t* x_map
-)
-{
-    const half* h_ptr = h_.item_ptr(h_row, 0);
-    const uint32_t* x_map_ptr = x_map + h_column;
-    const uint32_t* v_ptr = (const uint32_t*) v_.item_uint32_ptr(v_row, v_column);
-    half result = acc;
-
-    for (int i = 0; i < count; i++)
-    {
-        uint32_t v_read = *v_ptr; v_ptr += v_.width;
-
-        half v_0 = __int2half_rn((int)((v_read      ) & 0x0f) - v_zero);
-        half v_1 = __int2half_rn((int)((v_read >>  4) & 0x0f) - v_zero);
-        half v_2 = __int2half_rn((int)((v_read >>  8) & 0x0f) - v_zero);
-        half v_3 = __int2half_rn((int)((v_read >> 12) & 0x0f) - v_zero);
-        half v_4 = __int2half_rn((int)((v_read >> 16) & 0x0f) - v_zero);
-        half v_5 = __int2half_rn((int)((v_read >> 20) & 0x0f) - v_zero);
-        half v_6 = __int2half_rn((int)((v_read >> 24) & 0x0f) - v_zero);
-        half v_7 = __int2half_rn((int)((v_read >> 28)       ) - v_zero);
-
-        half tmp = __hmul(h_ptr[*x_map_ptr++], v_0);
-        tmp = __hfma(h_ptr[*x_map_ptr++], v_1, tmp);
-        tmp = __hfma(h_ptr[*x_map_ptr++], v_2, tmp);
-        tmp = __hfma(h_ptr[*x_map_ptr++], v_3, tmp);
-        tmp = __hfma(h_ptr[*x_map_ptr++], v_4, tmp);
-        tmp = __hfma(h_ptr[*x_map_ptr++], v_5, tmp);
-        tmp = __hfma(h_ptr[*x_map_ptr++], v_6, tmp);
-        tmp = __hfma(h_ptr[*x_map_ptr++], v_7, tmp);
         result = __hfma(v_scale, tmp, result);
     }
 


### PR DESCRIPTION
## Performance changes

Before:

```console
$ python test_benchmark_inference.py -p -d models/LLaMA-7B-4bit-128g -cs
/home/qc/Workspace/NotMe/exllama/cuda_ext.py:82: UserWarning: Failed to initialize NumPy: No module named 'numpy' (Triggered internally at ../torch/csrc/utils/tensor_numpy.cpp:84.)
  none_tensor = torch.empty((1, 1), device = "meta")
 -- Tokenizer: models/LLaMA-7B-4bit-128g/tokenizer.model
 -- Model config: models/LLaMA-7B-4bit-128g/config.json
 -- Model: models/LLaMA-7B-4bit-128g/llama-7b-4bit-128g.safetensors
 -- Sequence length: 2048
 -- Tuning:
 -- --sdp_thd: 8
 -- --matmul_recons_thd: 8
 -- --fused_mlp_thd: 2
 -- --concurrent_streams
 -- Options: ['perf']
 ** Time, Load model: 1.37 seconds
 ** Time, Load tokenizer: 0.01 seconds
 -- Groupsize (inferred): 128
 -- Act-order (inferred): yes
 ** VRAM, Model: [cuda:0] 3,638.47 MB
 ** VRAM, Cache: [cuda:0] 1,024.00 MB
 -- Warmup pass 1...
 ** Time, Warmup: 0.44 seconds
 -- Warmup pass 2...
 ** Time, Warmup: 0.42 seconds
 -- Inference, first pass.
 ** Time, Inference: 0.60 seconds
 ** Speed: 3212.74 tokens/second
 -- Generating 128 tokens, 1920 token prompt...
 ** Speed: 37.35 tokens/second
 -- Generating 128 tokens, 4 token prompt...
 ** Speed: 50.67 tokens/second
 ** VRAM, Inference: [cuda:0] 143.92 MB
 ** VRAM, Total: [cuda:0] 4,806.38 MB
```

After:

```console
$ python test_benchmark_inference.py -p -d models/LLaMA-7B-4bit-128g -cs
/home/qc/Workspace/NotMe/exllama/cuda_ext.py:82: UserWarning: Failed to initialize NumPy: No module named 'numpy' (Triggered internally at ../torch/csrc/utils/tensor_numpy.cpp:84.)
  none_tensor = torch.empty((1, 1), device = "meta")
 -- Tokenizer: models/LLaMA-7B-4bit-128g/tokenizer.model
 -- Model config: models/LLaMA-7B-4bit-128g/config.json
 -- Model: models/LLaMA-7B-4bit-128g/llama-7b-4bit-128g.safetensors
 -- Sequence length: 2048
 -- Tuning:
 -- --sdp_thd: 8
 -- --matmul_recons_thd: 8
 -- --fused_mlp_thd: 2
 -- --concurrent_streams
 -- Options: ['perf']
 ** Time, Load model: 1.42 seconds
 ** Time, Load tokenizer: 0.01 seconds
 -- Groupsize (inferred): 128
 -- Act-order (inferred): yes
 ** VRAM, Model: [cuda:0] 3,638.47 MB
 ** VRAM, Cache: [cuda:0] 1,024.00 MB
 -- Warmup pass 1...
 ** Time, Warmup: 0.44 seconds
 -- Warmup pass 2...
 ** Time, Warmup: 0.42 seconds
 -- Inference, first pass.
 ** Time, Inference: 0.60 seconds
 ** Speed: 3210.79 tokens/second
 -- Generating 128 tokens, 1920 token prompt...
 ** Speed: 80.41 tokens/second
 -- Generating 128 tokens, 4 token prompt...
 ** Speed: 152.34 tokens/second
 ** VRAM, Inference: [cuda:0] 143.92 MB
 ** VRAM, Total: [cuda:0] 4,806.38 MB
```

- 1920 token prompt: 2.15x speed
- 4 token prompt: 3x speed

Benchmarked on RTX 2070 Super. Other models cannot fit in VRAM. Expect less speedup if the model contains less `x_map`.

## PPL changes

Before:

```console
$ python test_benchmark_inference.py -ppl -d models/LLaMA-7B-4bit-128g  
/home/qc/Workspace/NotMe/exllama/cuda_ext.py:82: UserWarning: Failed to initialize NumPy: No module named 'numpy' (Triggered internally at ../torch/csrc/utils/tensor_numpy.cpp:84.)
  none_tensor = torch.empty((1, 1), device = "meta")
 -- Perplexity:
 -- - Dataset: datasets/wikitext2_val_sample.jsonl
 -- - Chunks: 100
 -- - Chunk size: 2048 -> 2048
 -- - Chunk overlap: 0
 -- - Min. chunk size: 50
 -- - Key: text
 -- Tokenizer: models/LLaMA-7B-4bit-128g/tokenizer.model
 -- Model config: models/LLaMA-7B-4bit-128g/config.json
 -- Model: models/LLaMA-7B-4bit-128g/llama-7b-4bit-128g.safetensors
 -- Sequence length: 2048
 -- Tuning:
 -- --sdp_thd: 8
 -- --matmul_recons_thd: 8
 -- --fused_mlp_thd: 2
 -- Options: ['perplexity']
 ** Time, Load model: 1.39 seconds
 ** Time, Load tokenizer: 0.01 seconds
 -- Groupsize (inferred): 128
 -- Act-order (inferred): yes
 ** VRAM, Model: [cuda:0] 3,638.47 MB
 ** VRAM, Cache: [cuda:0] 1,024.00 MB
 -- Loading dataset...
 -- Testing 100 chunks..........
 ** Perplexity: 6.0227
```

After:

```console
$ python test_benchmark_inference.py -ppl -d models/LLaMA-7B-4bit-128g
/home/qc/Workspace/NotMe/exllama/cuda_ext.py:82: UserWarning: Failed to initialize NumPy: No module named 'numpy' (Triggered internally at ../torch/csrc/utils/tensor_numpy.cpp:84.)
  none_tensor = torch.empty((1, 1), device = "meta")
 -- Perplexity:
 -- - Dataset: datasets/wikitext2_val_sample.jsonl
 -- - Chunks: 100
 -- - Chunk size: 2048 -> 2048
 -- - Chunk overlap: 0
 -- - Min. chunk size: 50
 -- - Key: text
 -- Tokenizer: models/LLaMA-7B-4bit-128g/tokenizer.model
 -- Model config: models/LLaMA-7B-4bit-128g/config.json
 -- Model: models/LLaMA-7B-4bit-128g/llama-7b-4bit-128g.safetensors
 -- Sequence length: 2048
 -- Tuning:
 -- --sdp_thd: 8
 -- --matmul_recons_thd: 8
 -- --fused_mlp_thd: 2
 -- Options: ['perplexity']
 ** Time, Load model: 1.40 seconds
 ** Time, Load tokenizer: 0.01 seconds
 -- Groupsize (inferred): 128
 -- Act-order (inferred): yes
 ** VRAM, Model: [cuda:0] 3,638.47 MB
 ** VRAM, Cache: [cuda:0] 1,024.00 MB
 -- Loading dataset...
 -- Testing 100 chunks..........
 ** Perplexity: 6.0232
```

Delta = 0.0005